### PR TITLE
added wget requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ curl -o- https://raw.githubusercontent.com/shawwn/llama-dl/56f50b96072f42fb2520b
 Mac:
 
 ```sh
-brew install bash
-curl -o- https://raw.githubusercontent.com/shawwn/llama-dl/56f50b96072f42fb2520b1ad5a1d6ef30351f23c/llama.sh | $(brew --prefix)/bin/bash
+brew install bash && brew install wget && curl -o- https://raw.githubusercontent.com/shawwn/llama-dl/56f50b96072f42fb2520b1ad5a1d6ef30351f23c/llama.sh | $(brew --prefix)/bin/bash
 ```
 
 (Sorry mac users; they use some array syntax in the script that isn't supported on the version of bash that ships with Mac.)


### PR DESCRIPTION
bash won't suffice since script does rely on 'wget', more clean way implemented for users to run on mac.